### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Download from JetBrains Plugin Repository: https://plugins.jetbrains.com/plugin/7972
 
-####Usage: 
+#### Usage: 
 1. copy lines with future style from your layout.xml file <br>
 ![step1](https://github.com/alexzaitsev/android-styler/blob/master/screenshots/01.jpg)
 2. paste it to styles.xml file with Ctrl+Shift+D (or context menu) <br>
@@ -13,12 +13,12 @@ Download from JetBrains Plugin Repository: https://plugins.jetbrains.com/plugin/
 4. your style is prepared! <br>
 ![step3](https://github.com/alexzaitsev/android-styler/blob/master/screenshots/03.jpg)
 
-####Changelog
+#### Changelog
 
-#####Version: 1.0.1
+##### Version: 1.0.1
 
   * Fix compatibility to make available for Android Studio
 
-#####Version: 1.0
+##### Version: 1.0
 
   * Pilot version


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
